### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ And then execute:
 
     $ bundle
 
+### Issue 2: Error 'cannot load such file -- kramdown-parser-gfm' when building site.
+
+Add this line to your `Gemfile`:
+
+```ruby
+gem "kramdown-parser-gfm"
+```
+
+And then execute:
+
+    $ bundle
+
 ## Usage
 
 TODO: Write usage instructions here. Describe your available layouts, includes, sass and/or assets.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Or install it yourself as:
 
     $ gem install jekyll-clf-theme
 
+## Troubleshooting
+
+### Issue 1: [Ruby versions greater than 3.0 do not have webrick](https://github.com/jekyll/jekyll/issues/8523). 
+
+Depending on your Ruby version you will need to add this line to your `Gemfile`:
+
+```ruby
+gem "webrick"
+```
+
+And then execute:
+
+    $ bundle
+
 ## Usage
 
 TODO: Write usage instructions here. Describe your available layouts, includes, sass and/or assets.


### PR DESCRIPTION
I had to add the following to my Gemfile:
 
```
gem "kramdown-parser-gfm"
gem "webrick"
```

The webrick dependency is a know issue with Ruby 3 and higher https://github.com/jekyll/jekyll/issues/8523
 
For reference I am using Ruby 3.2.3 and jekyll 3.9. 