### PR TITLE
Gemspec dependencies

### DIFF
--- a/jekyll-clf-theme.gemspec
+++ b/jekyll-clf-theme.gemspec
@@ -16,10 +16,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-feed", "~> 0.15"
   spec.add_runtime_dependency "jekyll-scholar", "~> 5.0"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
+  spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.0"
+  spec.add_runtime_dependency "webrick", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "kramdown-parser-gfm", "~> 1.0"
-  spec.add_development_dependency "webrick", "~> 1.0"
+
 
 end


### PR DESCRIPTION
From PR https://github.com/ubc-cpsc/jekyll-clf-theme/pull/6

It turns out I just needed to change the dependencies in gemspec from runtime to development - and then it works without needing to add webrick or kramdown-parser-gfm to the Gemfile!