### PR TITLE
UBC Unit Identifier Link

### DIFF
--- a/_includes/unit.html
+++ b/_includes/unit.html
@@ -13,7 +13,7 @@
                 <!-- Read more about Unit Name Treatment on http://brand.ubc.ca/clf -->
                 <!-- No Faculty Treatment --><!--<div id="ubc7-unit-name" class="ubc7-single-element"> -->
                 <div id="ubc7-unit-name"{% unless site.unit %} class="ubc7-single-element"{% endunless %}>
-                    <a href="/">
+                    <a href={{ "/" | relative_url }}> 
                         {% if site.unit %}
                         <span id="ubc7-unit-faculty">{{ site.unit }}</span>
                         {% endif %}


### PR DESCRIPTION
Process the link UBC Unit Identifier with the relative_url filter (ex. for https://www.cs.ubc.ca/labs/socius/ we want the site root to be https://www.cs.ubc.ca/labs/socius/ not https://www.cs.ubc.ca/).

This is similar to what is done in the nav bar.

See Issue #10